### PR TITLE
Remove unused fields

### DIFF
--- a/src/main/java/org/fedoraproject/javadeptools/rpm/Rpm.java
+++ b/src/main/java/org/fedoraproject/javadeptools/rpm/Rpm.java
@@ -32,10 +32,8 @@ final class Rpm {
 
     static final int RPMVSF_NOHDRCHK = 1 << 0;
     static final int RPMVSF_NOSHA1HEADER = 1 << 8;
-    static final int RPMVSF_NOMD5HEADER = 1 << 9;
     static final int RPMVSF_NODSAHEADER = 1 << 10;
     static final int RPMVSF_NORSAHEADER = 1 << 11;
-    static final int RPMVSF_NOSHA1 = 1 << 16;
     static final int RPMVSF_NOMD5 = 1 << 17;
     static final int RPMVSF_NODSA = 1 << 18;
     static final int RPMVSF_NORSA = 1 << 19;

--- a/src/main/java/org/fedoraproject/javadeptools/rpm/RpmInfo.java
+++ b/src/main/java/org/fedoraproject/javadeptools/rpm/RpmInfo.java
@@ -41,10 +41,8 @@ import static org.fedoraproject.javadeptools.rpm.Rpm.RPMVSF_NODSA;
 import static org.fedoraproject.javadeptools.rpm.Rpm.RPMVSF_NODSAHEADER;
 import static org.fedoraproject.javadeptools.rpm.Rpm.RPMVSF_NOHDRCHK;
 import static org.fedoraproject.javadeptools.rpm.Rpm.RPMVSF_NOMD5;
-import static org.fedoraproject.javadeptools.rpm.Rpm.RPMVSF_NOMD5HEADER;
 import static org.fedoraproject.javadeptools.rpm.Rpm.RPMVSF_NORSA;
 import static org.fedoraproject.javadeptools.rpm.Rpm.RPMVSF_NORSAHEADER;
-import static org.fedoraproject.javadeptools.rpm.Rpm.RPMVSF_NOSHA1;
 import static org.fedoraproject.javadeptools.rpm.Rpm.RPMVSF_NOSHA1HEADER;
 import static org.fedoraproject.javadeptools.rpm.Rpm.headerFree;
 import static org.fedoraproject.javadeptools.rpm.Rpm.headerGet;
@@ -98,8 +96,8 @@ public class RpmInfo {
         try {
             if (Ferror(fd))
                 throw error(path, Fstrerror(fd));
-            rpmtsSetVSFlags(ts, RPMVSF_NOHDRCHK | RPMVSF_NOSHA1HEADER | RPMVSF_NOMD5HEADER | RPMVSF_NODSAHEADER
-                    | RPMVSF_NORSAHEADER | RPMVSF_NOSHA1 | RPMVSF_NOMD5 | RPMVSF_NODSA | RPMVSF_NORSA);
+            rpmtsSetVSFlags(ts, RPMVSF_NOHDRCHK | RPMVSF_NOSHA1HEADER | RPMVSF_NODSAHEADER
+                    | RPMVSF_NORSAHEADER | RPMVSF_NOMD5 | RPMVSF_NODSA | RPMVSF_NORSA);
             Pointer ph = new Memory(Pointer.SIZE);
             int rc = rpmReadPackageFile(ts, fd, null, ph);
             if (rc == RPMRC_NOTFOUND)


### PR DESCRIPTION
According to some RPM docs, I can't remember where, these fields were never used and were removed in some newer version of RPM.