### PR TITLE
Don't leak preview bytecode into API classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,10 +73,39 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <version>3.11.0</version>
         <configuration>
           <release>21</release>
-          <compilerArgs>
-            <arg>--enable-preview</arg>
-          </compilerArgs>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <excludes>
+                <exclude>**/DynamicLinker.java</exclude>
+                <exclude>**/NativeInvocationHandler.java</exclude>
+                <exclude>**/NativePointerImpl.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>compile-preview</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <compilerArgs>
+                <arg>--enable-preview</arg>
+              </compilerArgs>
+              <includes>
+                <include>**/module-info.java</include>
+                <include>**/DynamicLinker.java</include>
+                <include>**/NativeInvocationHandler.java</include>
+                <include>**/NativePointerImpl.java</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/io/kojan/javadeptools/nativ/DynamicLinker.java
+++ b/src/main/java/io/kojan/javadeptools/nativ/DynamicLinker.java
@@ -61,6 +61,6 @@ class DynamicLinker implements SymbolLookup {
         if (sym == null) {
             return Optional.empty();
         }
-        return Optional.of(sym.ms);
+        return Optional.of((MemorySegment)sym.ms);
     }
 }

--- a/src/main/java/io/kojan/javadeptools/nativ/NativeDataStructure.java
+++ b/src/main/java/io/kojan/javadeptools/nativ/NativeDataStructure.java
@@ -15,13 +15,11 @@
  */
 package io.kojan.javadeptools.nativ;
 
-import java.lang.foreign.MemorySegment;
-
 /**
  * Native data structure.
  * 
  * @author Mikolaj Izdebski
  */
 public abstract class NativeDataStructure {
-    MemorySegment ms;
+    Object ms;
 }

--- a/src/main/java/io/kojan/javadeptools/nativ/NativeInvocationHandler.java
+++ b/src/main/java/io/kojan/javadeptools/nativ/NativeInvocationHandler.java
@@ -72,7 +72,7 @@ class NativeInvocationHandler implements InvocationHandler {
 
         public NativeDataStructure convert(Object obj) throws Throwable {
             NativeDataStructure nativ = (NativeDataStructure) ctr.newInstance();
-            nativ.ms = (MemorySegment) obj;
+            nativ.ms = obj;
             return nativ;
         }
 
@@ -119,8 +119,10 @@ class NativeInvocationHandler implements InvocationHandler {
         };
     }
 
-    public NativeInvocationHandler(SymbolLookup lookup, Linker linker, Class<?> iface)
-            throws ReflectiveOperationException {
+    public NativeInvocationHandler(Class<?> iface, String lib) throws ReflectiveOperationException {
+
+        Linker linker = Linker.nativeLinker();
+        SymbolLookup lookup = lib != null ? new DynamicLinker(lib) : linker.defaultLookup();
 
         for (Method method : iface.getDeclaredMethods()) {
             MemoryLayout[] argLayouts = new MemoryLayout[method.getParameterCount()];

--- a/src/main/java/io/kojan/javadeptools/nativ/NativePointer.java
+++ b/src/main/java/io/kojan/javadeptools/nativ/NativePointer.java
@@ -15,41 +15,11 @@
  */
 package io.kojan.javadeptools.nativ;
 
-import java.lang.foreign.Arena;
-import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
-import java.lang.reflect.Constructor;
-
 /**
  * Native pointer to a native data structure.
  * 
  * @author Mikolaj Izdebski
  */
-public class NativePointer<T extends NativeDataStructure> extends NativeDataStructure {
-
-    private final Constructor<T> ctr;
-
-    public NativePointer(Class<T> type) {
-        try {
-            ctr = type.getDeclaredConstructor();
-            ctr.setAccessible(true);
-            this.ms = Arena.ofAuto().allocate(ValueLayout.ADDRESS);
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public T dereference() {
-        MemorySegment address = ms.get(ValueLayout.ADDRESS, 0);
-        if (address.equals(MemorySegment.NULL)) {
-            return null;
-        }
-        try {
-            T obj = ctr.newInstance();
-            obj.ms = address;
-            return obj;
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
-        }
-    }
+public abstract class NativePointer<T extends NativeDataStructure> extends NativeDataStructure {
+    public abstract T dereference();
 }

--- a/src/main/java/io/kojan/javadeptools/nativ/NativePointerImpl.java
+++ b/src/main/java/io/kojan/javadeptools/nativ/NativePointerImpl.java
@@ -1,0 +1,55 @@
+/*-
+ * Copyright (c) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kojan.javadeptools.nativ;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.reflect.Constructor;
+
+/**
+ * Internal implementation of native pointer to a native data structure.
+ * 
+ * @author Mikolaj Izdebski
+ */
+class NativePointerImpl<T extends NativeDataStructure> extends NativePointer<T> {
+
+    private final Constructor<T> ctr;
+
+    public NativePointerImpl(Class<T> type) {
+        try {
+            ctr = type.getDeclaredConstructor();
+            ctr.setAccessible(true);
+            ms = Arena.ofAuto().allocate(ValueLayout.ADDRESS);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public T dereference() {
+        MemorySegment address = ((MemorySegment) ms).get(ValueLayout.ADDRESS, 0);
+        if (address.equals(MemorySegment.NULL)) {
+            return null;
+        }
+        try {
+            T obj = ctr.newInstance();
+            obj.ms = address;
+            return obj;
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/io/kojan/javadeptools/rpm/RpmPackage.java
+++ b/src/main/java/io/kojan/javadeptools/rpm/RpmPackage.java
@@ -20,6 +20,7 @@ import static io.kojan.javadeptools.rpm.Rpm.*;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import io.kojan.javadeptools.nativ.Native;
 import io.kojan.javadeptools.nativ.NativePointer;
 
 /**
@@ -43,7 +44,7 @@ public class RpmPackage {
                 throw error(path, Fstrerror(fd));
             rpmtsSetVSFlags(ts, RPMVSF_NOHDRCHK | RPMVSF_NOSHA1HEADER | RPMVSF_NODSAHEADER | RPMVSF_NORSAHEADER
                     | RPMVSF_NOMD5 | RPMVSF_NODSA | RPMVSF_NORSA);
-            NativePointer<RpmHeader> ph = new NativePointer<>(RpmHeader.class);
+            NativePointer<RpmHeader> ph = Native.newPointer(RpmHeader.class);
             int rc = rpmReadPackageFile(ts, fd, null, ph);
             if (rc == RPMRC_NOTFOUND)
                 throw error(path, "Not a RPM file");


### PR DESCRIPTION
API classes should not have preview bytecode, so that clients using the API don't need to compile with `--enable-preview`.